### PR TITLE
chore(redhat): update url

### DIFF
--- a/redhat/csaf/vex.go
+++ b/redhat/csaf/vex.go
@@ -22,7 +22,7 @@ import (
 const (
 	vexDir  = "csaf-vex"
 	retry   = 5
-	baseURL = "https://access.redhat.com/security/data/csaf/v2/vex/"
+	baseURL = "https://security.access.redhat.com/data/csaf/v2/vex/"
 )
 
 type Option func(*Config)

--- a/redhat/oval/redhat.go
+++ b/redhat/oval/redhat.go
@@ -25,11 +25,11 @@ const (
 	ovalDir = "oval"
 	cpeDir  = "cpe"
 
-	urlFormat    = "https://www.redhat.com/security/data/oval/v2/%s"
+	urlFormat    = "https://security.access.redhat.com/data/oval/v2/%s"
 	retry        = 5
 	pulpManifest = "PULP_MANIFEST"
 
-	repoToCpeURL = "https://www.redhat.com/security/data/metrics/repository-to-cpe.json"
+	repoToCpeURL = "https://security.access.redhat.com/data/meta/v1/repository-to-cpe.json"
 
 	testsDir       = "tests"
 	objectsDir     = "objects"


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3

## Summary by Sourcery

Chores:
- Update the base URL from "access.redhat.com" to "security.access.redhat.com".