### PR TITLE
chore(deps): bump golangci/golangci-lint-action from 6.2.0 to 7.0.0

### DIFF
--- a/mariner/mariner.go
+++ b/mariner/mariner.go
@@ -106,7 +106,7 @@ func (c Config) Update() error {
 			continue
 		}
 
-		if !(strings.HasPrefix(entry.Name(), marinerPrefix) || strings.HasPrefix(entry.Name(), azurePrefix)) {
+		if !strings.HasPrefix(entry.Name(), marinerPrefix) && !strings.HasPrefix(entry.Name(), azurePrefix) {
 			continue
 		}
 		if filepath.Ext(entry.Name()) != ".xml" {


### PR DESCRIPTION
Addresses issue: #

Changes proposed in this pull request:

- Change 1
- Change 2
- Change 3
